### PR TITLE
start recording error notifications

### DIFF
--- a/ceilometer/event/endpoint.py
+++ b/ceilometer/event/endpoint.py
@@ -57,6 +57,23 @@ class EventsNotificationEndpoint(object):
             'info', ctxt, publisher_id, event_type, payload, metadata)
         self.process_notification(notification)
 
+    def error(self, ctxt, publisher_id, event_type, payload, metadata):
+        """Convert error message to Ceilometer Event.
+
+        :param ctxt: oslo.messaging context
+        :param publisher_id: publisher of the notification
+        :param event_type: type of notification
+        :param payload: notification payload
+        :param metadata: metadata about the notification
+        """
+
+        # NOTE: the rpc layer currently rips out the notification
+        # delivery_info, which is critical to determining the
+        # source of the notification. This will have to get added back later.
+        notification = messaging.convert_to_old_notification_format(
+            'error', ctxt, publisher_id, event_type, payload, metadata)
+        self.process_notification(notification)
+
     def process_notification(self, notification):
         event = self.event_converter.to_event(notification)
 


### PR DESCRIPTION
projects (specifically nova) send notifications on error topic when
an error occurs. we should capture this in events.

Change-Id: Ic42cbce948b8b409f83934146407b2480602921d
Closes-Bug: #1364708
(cherry picked from commit f7ed2c2a16e8dded6bd2258ea0a5e5954a13bada)

Bug-ES #9569
http://192.168.15.2/issues/9569