### PR TITLE
neutron_client: fix wrong filter in port_get_hosted

### DIFF
--- a/ceilometer/neutron_client.py
+++ b/ceilometer/neutron_client.py
@@ -148,5 +148,5 @@ class Client(object):
 
     @logged
     def port_get_hosted(self):
-        resp = self.client.list_ports(host=cfg.CONF.host)
+        resp = self.client.list_ports(**{'binding:host_id': cfg.CONF.host})
         return resp.get('ports', [])


### PR DESCRIPTION
Fixes: redmine #9155
Fixes: 434b58a3 ("Add instance ports traffic meter")

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>