### PR TITLE
Fix ceilometer-collector server error

### DIFF
--- a/ceilometer/dispatcher/__init__.py
+++ b/ceilometer/dispatcher/__init__.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import abc
+import time
 
 from oslo.config import cfg
 import six
@@ -42,14 +43,21 @@ DISPATCHER_NAMESPACE = 'ceilometer.dispatcher'
 def load_dispatcher_manager():
     LOG.debug(_('loading dispatchers from %s'),
               DISPATCHER_NAMESPACE)
-    dispatcher_manager = named.NamedExtensionManager(
-        namespace=DISPATCHER_NAMESPACE,
-        names=cfg.CONF.dispatcher,
-        invoke_on_load=True,
-        invoke_args=[cfg.CONF])
-    if not list(dispatcher_manager):
-        LOG.warning(_('Failed to load any dispatchers for %s'),
-                    DISPATCHER_NAMESPACE)
+
+    # When dispatcher_manager get faild, The dispatcher_manager it's
+    # going to run all the time.
+    while True:
+        dispatcher_manager = named.NamedExtensionManager(
+            namespace=DISPATCHER_NAMESPACE,
+            names=cfg.CONF.dispatcher,
+            invoke_on_load=True,
+            invoke_args=[cfg.CONF])
+        if not list(dispatcher_manager):
+            LOG.warning(_('Failed to load any dispatchers for %s'),
+                        DISPATCHER_NAMESPACE)
+            time.sleep(60)
+        else:
+            break
     return dispatcher_manager
 
 


### PR DESCRIPTION
This patch fix when ceilometer-collector start,
the mongod server not right. After time the mongod
recover right, the ceilometer-collector is not
running right.

Bug-ES #11201
http://192.168.15.2/issues/11201

Signed-off-by: Yuanbin.Chen <cybing4@gmail.com>